### PR TITLE
Add teachers' names context menus (dialogs)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -33,8 +33,8 @@
 
 -keepnames class androidx.appcompat.view.menu.MenuBuilder { setHeaderTitleInt(java.lang.CharSequence); }
 -keepnames class androidx.appcompat.view.menu.MenuPopupHelper { showPopup(int, int, boolean, boolean); }
--keepclassmembernames class androidx.appcompat.view.menu.StandardMenuPopup { private mShowTitle; }
--keepclassmembernames class androidx.appcompat.view.menu.MenuItemImpl { private mClickListener; }
+-keepclassmembernames class androidx.appcompat.view.menu.StandardMenuPopup { private *; }
+-keepclassmembernames class androidx.appcompat.view.menu.MenuItemImpl { private *; }
 
 -keepclassmembernames class com.mikepenz.materialdrawer.widget.MiniDrawerSliderView { private *; }
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,8 +32,9 @@
 -keepnames class pl.szczodrzynski.edziennik.ui.widgets.luckynumber.WidgetLuckyNumberProvider
 
 -keepnames class androidx.appcompat.view.menu.MenuBuilder { setHeaderTitleInt(java.lang.CharSequence); }
--keepclassmembernames class androidx.appcompat.view.menu.StandardMenuPopup { private *; }
 -keepnames class androidx.appcompat.view.menu.MenuPopupHelper { showPopup(int, int, boolean, boolean); }
+-keepclassmembernames class androidx.appcompat.view.menu.StandardMenuPopup { private mShowTitle; }
+-keepclassmembernames class androidx.appcompat.view.menu.MenuItemImpl { private mClickListener; }
 
 -keepclassmembernames class com.mikepenz.materialdrawer.widget.MiniDrawerSliderView { private *; }
 

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/dialogs/event/EventDetailsDialog.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/dialogs/event/EventDetailsDialog.kt
@@ -199,10 +199,14 @@ class EventDetailsDialog(
         }
         b.downloadButton.attachToastHint(R.string.hint_download_again)
 
+        BetterLink.attach(b.topic, onActionSelected = dialog::dismiss)
 
-        b.topic.text = event.topic
-        BetterLink.attach(b.topic) {
-            dialog.dismiss()
+        event.teacherName?.let { name ->
+            BetterLink.attach(
+                b.teacherName,
+                teachers = mapOf(event.teacherId to name),
+                onActionSelected = dialog::dismiss
+            )
         }
 
         if (event.homeworkBody == null && !event.addedManually && event.type == Event.TYPE_HOMEWORK) {
@@ -220,10 +224,7 @@ class EventDetailsDialog(
             b.bodyTitle.isVisible = true
             b.bodyProgressBar.isVisible = false
             b.body.isVisible = true
-            b.body.text = event.homeworkBody
-            BetterLink.attach(b.body) {
-                dialog.dismiss()
-            }
+            BetterLink.attach(b.body, onActionSelected = dialog::dismiss)
         }
 
         if (event.attachmentIds.isNullOrEmpty() || event.attachmentNames.isNullOrEmpty()) {

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/dialogs/grade/GradeDetailsDialog.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/dialogs/grade/GradeDetailsDialog.kt
@@ -14,6 +14,7 @@ import pl.szczodrzynski.edziennik.databinding.DialogGradeDetailsBinding
 import pl.szczodrzynski.edziennik.onClick
 import pl.szczodrzynski.edziennik.setTintColor
 import pl.szczodrzynski.edziennik.ui.modules.grades.GradesAdapter
+import pl.szczodrzynski.edziennik.utils.BetterLink
 import pl.szczodrzynski.edziennik.utils.SimpleDividerItemDecoration
 import kotlin.coroutines.CoroutineContext
 
@@ -66,6 +67,14 @@ class GradeDetailsDialog(
         b.customValueLayout.isVisible = b.customValueDivider.isVisible
         b.customValueButton.onClick {
             GradesConfigDialog(activity, reloadOnDismiss = true)
+        }
+
+        grade.teacherName?.let { name ->
+            BetterLink.attach(
+                b.teacherName,
+                teachers = mapOf(grade.teacherId to name),
+                onActionSelected = dialog::dismiss
+            )
         }
 
         launch {

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/dialogs/timetable/LessonDetailsDialog.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/dialogs/timetable/LessonDetailsDialog.kt
@@ -25,6 +25,7 @@ import pl.szczodrzynski.edziennik.ui.dialogs.event.EventDetailsDialog
 import pl.szczodrzynski.edziennik.ui.dialogs.event.EventListAdapter
 import pl.szczodrzynski.edziennik.ui.dialogs.event.EventManualDialog
 import pl.szczodrzynski.edziennik.ui.modules.timetable.TimetableFragment
+import pl.szczodrzynski.edziennik.utils.BetterLink
 import pl.szczodrzynski.edziennik.utils.SimpleDividerItemDecoration
 import pl.szczodrzynski.edziennik.utils.models.Date
 import pl.szczodrzynski.edziennik.utils.models.Week
@@ -216,5 +217,19 @@ class LessonDetailsDialog(
                 b.eventsNoData.visibility = View.VISIBLE
             }
         })
+
+        lesson.displayTeacherName?.let { name ->
+            lesson.displayTeacherId ?: return@let
+            BetterLink.attach(
+                b.teacherNameView,
+                teachers = mapOf(lesson.displayTeacherId!! to name),
+                onActionSelected = dialog::dismiss
+            )
+            BetterLink.attach(
+                b.oldTeacherNameView,
+                teachers = mapOf(lesson.displayTeacherId!! to name),
+                onActionSelected = dialog::dismiss
+            )
+        }
     }
 }

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/attendance/AttendanceDetailsDialog.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/attendance/AttendanceDetailsDialog.kt
@@ -16,6 +16,7 @@ import pl.szczodrzynski.edziennik.R
 import pl.szczodrzynski.edziennik.data.db.full.AttendanceFull
 import pl.szczodrzynski.edziennik.databinding.AttendanceDetailsDialogBinding
 import pl.szczodrzynski.edziennik.setTintColor
+import pl.szczodrzynski.edziennik.utils.BetterLink
 import kotlin.coroutines.CoroutineContext
 
 class AttendanceDetailsDialog(
@@ -60,5 +61,13 @@ class AttendanceDetailsDialog(
         b.attendanceName.background.setTintColor(attendanceColor)
 
         b.attendanceIsCounted.setText(if (attendance.isCounted) R.string.yes else R.string.no)
+
+        attendance.teacherName?.let { name ->
+            BetterLink.attach(
+                b.teacherName,
+                teachers = mapOf(attendance.teacherId to name),
+                onActionSelected = dialog::dismiss
+            )
+        }
     }}
 }

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/behaviour/NoticesAdapter.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/behaviour/NoticesAdapter.kt
@@ -21,6 +21,7 @@ import pl.szczodrzynski.edziennik.R
 import pl.szczodrzynski.edziennik.data.api.LOGIN_TYPE_MOBIDZIENNIK
 import pl.szczodrzynski.edziennik.data.db.entity.Notice
 import pl.szczodrzynski.edziennik.data.db.full.NoticeFull
+import pl.szczodrzynski.edziennik.utils.BetterLink
 import pl.szczodrzynski.edziennik.utils.Utils.bs
 import pl.szczodrzynski.edziennik.utils.models.Date
 
@@ -82,6 +83,14 @@ class NoticesAdapter//getting the context and product list with constructor
             AsyncTask.execute { app.db.metadataDao().setSeen(App.profileId, notice, true) }
         } else {
             holder.noticesItemReason.background = null
+        }
+
+        BetterLink.attach(holder.noticesItemReason)
+
+        notice.teacherName?.let { name ->
+            BetterLink.attach(holder.noticesItemTeacherName, teachers = mapOf(
+                notice.teacherId to name
+            ))
         }
     }
 

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/messages/compose/MessagesComposeFragment.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/messages/compose/MessagesComposeFragment.kt
@@ -345,6 +345,7 @@ class MessagesComposeFragment : Fragment(), CoroutineScope {
         b.recipients.setAdapter(adapter)
 
         handleReplyMessage()
+        handleMailToIntent()
     }}
 
     private fun handleReplyMessage() { launch {
@@ -401,6 +402,22 @@ class MessagesComposeFragment : Fragment(), CoroutineScope {
             b.recipients.requestFocus()
         }
     }}
+
+    private fun handleMailToIntent() {
+        val teacherId = arguments?.getLong("messageRecipientId")
+        if (teacherId == 0L)
+            return
+
+        val chipList = mutableListOf<ChipInfo>()
+        teachers.firstOrNull { it.id == teacherId }?.let { teacher ->
+            teacher.image = getProfileImage(48, 24, 16, 12, 1, teacher.fullName)
+            chipList += ChipInfo(teacher.fullName, teacher)
+        }
+        b.recipients.addTextWithChips(chipList)
+
+        val subject = arguments?.getString("messageSubject")
+        b.subject.setText(subject ?: return)
+    }
 
     private fun sendMessage() {
         b.recipientsLayout.error = null

--- a/app/src/main/res/layout/attendance_details_dialog.xml
+++ b/app/src/main/res/layout/attendance_details_dialog.xml
@@ -94,6 +94,7 @@
                 android:textAppearance="@style/NavView.TextView.Helper" />
 
             <TextView
+                android:id="@+id/teacherName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="0dp"

--- a/app/src/main/res/layout/dialog_event_details.xml
+++ b/app/src/main/res/layout/dialog_event_details.xml
@@ -112,6 +112,7 @@
                 android:text="@string/dialog_event_details_teacher"
                 android:visibility="@{event.teacherName != null ? View.VISIBLE : View.GONE}"/>
             <TextView
+                android:id="@+id/teacherName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@{event.teacherName}"

--- a/app/src/main/res/layout/dialog_grade_details.xml
+++ b/app/src/main/res/layout/dialog_grade_details.xml
@@ -121,6 +121,7 @@
                 android:textAppearance="@style/NavView.TextView.Helper" />
 
             <TextView
+                android:id="@+id/teacherName"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="0dp"

--- a/app/src/main/res/layout/dialog_lesson_details.xml
+++ b/app/src/main/res/layout/dialog_lesson_details.xml
@@ -176,6 +176,7 @@
                         android:textAppearance="@style/NavView.TextView.Helper"
                         android:text="@string/dialog_lesson_details_teacher" />
                     <TextView
+                        android:id="@+id/oldTeacherNameView"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:textAppearance="@style/NavView.TextView.Helper"
@@ -186,6 +187,7 @@
                         app:strikeThrough="@{true}"
                         tools:text="Janósz Kowalski" />
                     <TextView
+                        android:id="@+id/teacherNameView"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@{teacherName}"


### PR DESCRIPTION
This PR modifies BetterLink to support linking teachers' names (to compose a message) and linkifies names in most dialogs (grades, events, attendance, timetable).
![obraz](https://user-images.githubusercontent.com/30433568/113927412-bc78aa80-97ed-11eb-9920-2878b271b999.png)

Resolves #17.
