### PR TITLE
[Mobidziennik] Fix missing linebreaks when sending messages.

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/messages/compose/MessagesComposeFragment.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/messages/compose/MessagesComposeFragment.kt
@@ -503,10 +503,14 @@ class MessagesComposeFragment : Fragment(), CoroutineScope {
             text.toString()
         }
 
+        textHtml = textHtml
+            .replace("</b><b>", "")
+            .replace("</i><i>", "")
+            .replace("p style=\"margin-top:0; margin-bottom:0;\"", "p")
+
         if (app.profile.loginStoreType == LoginStore.LOGIN_TYPE_MOBIDZIENNIK) {
             textHtml = textHtml
-                    .replace("p style=\"margin-top:0; margin-bottom:0;\"", "span")
-                    .replace("</p>", "</span>")
+                    .replace("</p><br>", "</p>")
                     .replace("<b>", "<strong>")
                     .replace("</b>", "</strong>")
                     .replace("<i>", "<em>")


### PR DESCRIPTION
Closes #an-issue-nobody-noticed.

Messages sent through Szkolny.eu in Mobidziennik were having half linebreaks (i.e. to send a newline you had to press enter twice).

This PR (hopefully) fixes that issue.