### PR TITLE
[UI] Fix restoring header background dialog.

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/settings/cards/SettingsThemeCard.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/settings/cards/SettingsThemeCard.kt
@@ -88,7 +88,7 @@ class SettingsThemeCard(util: SettingsUtil) : SettingsCard(util) {
             text = R.string.settings_theme_drawer_header_text,
             icon = CommunityMaterial.Icon2.cmd_image_outline
         ) {
-            if (app.config.ui.appBackground == null) {
+            if (app.config.ui.headerBackground == null) {
                 setHeaderBackground()
                 return@createActionItem
             }


### PR DESCRIPTION
This fixes a typo in the code where the "set/restore header background" dialog would not show unless the app background was set.