### PR TITLE
[Messages] Fix downloading and displaying attachment on API 30+.

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/views/AttachmentsView.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/views/AttachmentsView.kt
@@ -80,6 +80,7 @@ class AttachmentsView @JvmOverloads constructor(
             list.adapter = adapter
             list.apply {
                 setHasFixedSize(false)
+                isNestedScrollingEnabled = false
                 layoutManager = LinearLayoutManager(context)
                 addItemDecoration(SimpleDividerItemDecoration(context))
             }

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/views/AttachmentsView.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/views/AttachmentsView.kt
@@ -37,9 +37,7 @@ class AttachmentsView @JvmOverloads constructor(
     }
 
     private val storageDir by lazy {
-        val storageDir = Environment.getExternalStoragePublicDirectory("Szkolny.eu")
-        storageDir.mkdirs()
-        storageDir
+        Utils.getStorageDir()
     }
 
     fun init(arguments: Bundle, owner: Any) {

--- a/app/src/main/java/pl/szczodrzynski/edziennik/utils/Utils.java
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/utils/Utils.java
@@ -776,7 +776,8 @@ public class Utils {
     public static File getStorageDir() {
         if (storageDir != null)
             return storageDir;
-        storageDir = Environment.getExternalStoragePublicDirectory("Szkolny.eu");
+        storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+        storageDir = new File(storageDir, "Szkolny.eu");
         storageDir.mkdirs();
         return storageDir;
     }

--- a/app/src/main/res/layout/message_fragment.xml
+++ b/app/src/main/res/layout/message_fragment.xml
@@ -57,7 +57,7 @@
             android:visibility="visible"
             tools:visibility="gone"/>
 
-        <ScrollView
+        <androidx.core.widget.NestedScrollView
             android:id="@+id/content"
             android:layout_width="match_parent"
             android:layout_height="0dp"
@@ -306,6 +306,6 @@
                     </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
-        </ScrollView>
+        </androidx.core.widget.NestedScrollView>
     </LinearLayout>
 </layout>


### PR DESCRIPTION
Closes #58 and related errors (ENOENT / ENOPERM).
Also fixes an issue on Android 11+ where only one attachment is visible due to nested scrolling issues.