### PR TITLE
[API/Mobidziennik] Fix showing homework attachments.

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/Regexes.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/Regexes.kt
@@ -54,14 +54,15 @@ object Regexes {
         """events: (.+),$""".toRegex(RegexOption.MULTILINE)
     }
 
+    val MOBIDZIENNIK_WEB_ATTACHMENT by lazy {
+        """href="https://.+?\.mobidziennik.pl/.+?&(?:amp;)?zalacznik(_rozwiazania)?=([0-9]+)".+?>(.+?)(?: <small.+?\(([0-9.]+)\s(M|K|G|)B\)</small>)?</a>""".toRegex()
+    }
+
     val MOBIDZIENNIK_MESSAGE_READ_DATE by lazy {
         """czas przeczytania:.+?,\s([0-9]+)\s(.+?)\s([0-9]{4}),\sgodzina\s([0-9:]+)""".toRegex(DOT_MATCHES_ALL)
     }
     val MOBIDZIENNIK_MESSAGE_SENT_READ_DATE by lazy {
         """.+?,\s([0-9]+)\s(.+?)\s([0-9]{4}),\sgodzina\s([0-9:]+)""".toRegex(DOT_MATCHES_ALL)
-    }
-    val MOBIDZIENNIK_MESSAGE_ATTACHMENT by lazy {
-        """href="https://.+?\.mobidziennik.pl/.+?&(?:amp;)?zalacznik=([0-9]+)"(?:.+?<small.+?\(([0-9.]+)\s(M|K|G|)B\))*""".toRegex(DOT_MATCHES_ALL)
     }
     val MOBIDZIENNIK_MESSAGE_SENT_READ_BY by lazy {
         """([0-9]+)/([0-9]+)""".toRegex()
@@ -104,20 +105,24 @@ object Regexes {
         """<strong>(.+?)</strong>\s*<small>\s*\((.+?),\s*(.+?)\)""".toRegex(DOT_MATCHES_ALL)
     }
 
-    val MOBIDZIENNIK_HOMEWORK_ROW by lazy {
+    val MOBIDZIENNIK_MOBILE_HOMEWORK_ROW by lazy {
         """class="rowRolling">(.+?</div>\s*</td>)""".toRegex(DOT_MATCHES_ALL)
     }
-    val MOBIDZIENNIK_HOMEWORK_ITEM by lazy {
+    val MOBIDZIENNIK_MOBILE_HOMEWORK_ITEM by lazy {
         """<p><b>(.+?):</b>\s*(.+?)\s*</p>""".toRegex(DOT_MATCHES_ALL)
     }
-    val MOBIDZIENNIK_HOMEWORK_BODY by lazy {
+    val MOBIDZIENNIK_MOBILE_HOMEWORK_BODY by lazy {
         """Treść:</b>(.+?)<p><b>""".toRegex(DOT_MATCHES_ALL)
     }
-    val MOBIDZIENNIK_HOMEWORK_ID by lazy {
-        """zadanieFormularz\(([0-9]+),""".toRegex(DOT_MATCHES_ALL)
+    val MOBIDZIENNIK_MOBILE_HOMEWORK_ID by lazy {
+        """name="id_zadania" value="([0-9]+)"""".toRegex(DOT_MATCHES_ALL)
     }
-    val MOBIDZIENNIK_HOMEWORK_ATTACHMENT by lazy {
+    val MOBIDZIENNIK_MOBILE_HOMEWORK_ATTACHMENT by lazy {
         """zalacznik(_zadania)?=([0-9]+)'.+?word-break">(.+?)</td>""".toRegex(DOT_MATCHES_ALL)
+    }
+
+    val MOBIDZIENNIK_WEB_HOMEWORK_ADDED_DATE by lazy {
+        """Wpisał\(a\):</td>\s+<th>\s+(.+?), (.+?), ([0-9]{1,2}) (.+?) ([0-9]{4}), godzina ([0-9:]+)""".toRegex()
     }
 
 

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/edudziennik/data/web/EdudziennikWebGetHomework.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/edudziennik/data/web/EdudziennikWebGetHomework.kt
@@ -29,6 +29,7 @@ class EdudziennikWebGetHomework(
                 if (description != null) event.topic = Html.fromHtml(description).toString()
 
                 event.homeworkBody = ""
+                event.isDownloaded = true
                 event.attachmentNames = null
 
                 data.eventList += event

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/librus/data/synergia/LibrusSynergiaGetHomework.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/librus/data/synergia/LibrusSynergiaGetHomework.kt
@@ -24,6 +24,7 @@ class LibrusSynergiaGetHomework(override val data: DataLibrus,
 
             event.topic = table[1].select("td")[1].text()
             event.homeworkBody = Html.fromHtml(table[5].select("td")[1].html()).toString()
+            event.isDownloaded = true
 
             event.attachmentIds = mutableListOf()
             event.attachmentNames = mutableListOf()

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/librus/data/synergia/LibrusSynergiaHomework.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/librus/data/synergia/LibrusSynergiaHomework.kt
@@ -79,6 +79,7 @@ class LibrusSynergiaHomework(override val data: DataLibrus,
                             teamId = data.teamClass?.id ?: -1,
                             addedDate = addedDate.inMillis
                     )
+                    eventObject.isDownloaded = false
 
                     data.eventList.add(eventObject)
                     data.metadataList.add(Metadata(

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebGetEvent.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebGetEvent.kt
@@ -42,9 +42,9 @@ class MobidziennikWebGetEvent(
 
                 event.topic = topic
                 event.homeworkBody = body
+                event.isDownloaded = true
                 event.teacherId = teacher.id
                 event.addedDate = addedDate.inMillis
-                event.isDownloaded = true
             }
 
             data.eventList.add(event)

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebGetHomework.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebGetHomework.kt
@@ -12,40 +12,57 @@ import pl.szczodrzynski.edziennik.data.api.events.EventGetEvent
 import pl.szczodrzynski.edziennik.data.db.full.EventFull
 import pl.szczodrzynski.edziennik.get
 import pl.szczodrzynski.edziennik.utils.models.Date
+import pl.szczodrzynski.edziennik.utils.models.Time
 
 class MobidziennikWebGetHomework(override val data: DataMobidziennik,
                                  val event: EventFull,
                                  val onSuccess: () -> Unit
 ) : MobidziennikWeb(data, null) {
     companion object {
-        private const val TAG = "MobidziennikWebHomework"
+        private const val TAG = "MobidziennikWebGetHomework"
     }
 
     init {
-        val endpoint = if (event.date >= Date.getToday())
-            "zadaniadomowe"
-        else
-            "zadaniadomowearchiwalne"
-
-        webGet(TAG, "/mobile/$endpoint") { text ->
+        webGet(TAG, "/dziennik/wyslijzadanie/?id_zadania=${event.id}&uczen=${data.studentId}") { text ->
             MobidziennikLuckyNumberExtractor(data, text)
 
-            Regexes.MOBIDZIENNIK_HOMEWORK_ROW.findAll(text).forEach { homeworkMatch ->
-                val tableRow = homeworkMatch[1].ifBlank { return@forEach }
-
-                val id = Regexes.MOBIDZIENNIK_HOMEWORK_ID.find(tableRow)?.get(1)?.toLongOrNull() ?: return@forEach
-                if (event.id != id)
+            event.clearAttachments()
+            Regexes.MOBIDZIENNIK_WEB_ATTACHMENT.findAll(text).forEach { match ->
+                if (match[1].isNotEmpty())
                     return@forEach
-
-                event.attachmentIds = mutableListOf()
-                event.attachmentNames = mutableListOf()
-                Regexes.MOBIDZIENNIK_HOMEWORK_ATTACHMENT.findAll(tableRow).forEach {
-                    event.attachmentIds?.add(it[2].toLongOrNull() ?: return@forEach)
-                    event.attachmentNames?.add(it[3])
-                }
-
-                event.homeworkBody = ""
+                val attachmentId = match[2].toLong()
+                val attachmentName = match[3]
+                event.addAttachment(attachmentId, attachmentName)
             }
+
+            Regexes.MOBIDZIENNIK_WEB_HOMEWORK_ADDED_DATE.find(text)?.let {
+                // (Kowalski Jan), (wtorek), (2) (stycznia) (2019), godzina (12:34:56)
+                val month = when (it[4]) {
+                    "stycznia" -> 1
+                    "lutego" -> 2
+                    "marca" -> 3
+                    "kwietnia" -> 4
+                    "maja" -> 5
+                    "czerwca" -> 6
+                    "lipca" -> 7
+                    "sierpnia" -> 8
+                    "września" -> 9
+                    "października" -> 10
+                    "listopada" -> 11
+                    "grudnia" -> 12
+                    else -> 1
+                }
+                val addedDate = Date(
+                    it[5].toInt(),
+                    month,
+                    it[3].toInt()
+                )
+                val time = Time.fromH_m_s(it[6])
+                event.addedDate = addedDate.combineWith(time)
+            }
+
+            event.homeworkBody = ""
+            event.isDownloaded = true
 
             data.eventList.add(event)
             data.eventListReplace = true

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebGetMessage.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebGetMessage.kt
@@ -118,18 +118,16 @@ class MobidziennikWebGetMessage(override val data: DataMobidziennik,
                 this.body = body.html()
 
                 clearAttachments()
-                content.select("ul li").map { it.select("a").first() }.forEach {
-                    val attachmentName = it.ownText()
-                    Regexes.MOBIDZIENNIK_MESSAGE_ATTACHMENT.find(it.outerHtml())?.let { match ->
-                        val attachmentId = match[1].toLong()
-                        var size = match[2].toFloatOrNull() ?: -1f
-                        when (match[3]) {
-                            "K" -> size *= 1024f
-                            "M" -> size *= 1024f * 1024f
-                            "G" -> size *= 1024f * 1024f * 1024f
-                        }
-                        message.addAttachment(attachmentId, attachmentName, size.toLong())
+                Regexes.MOBIDZIENNIK_WEB_ATTACHMENT.findAll(text).forEach { match ->
+                    val attachmentId = match[2].toLong()
+                    val attachmentName = match[3]
+                    var size = match[4].toFloatOrNull() ?: -1f
+                    when (match[5]) {
+                        "K" -> size *= 1024f
+                        "M" -> size *= 1024f * 1024f
+                        "G" -> size *= 1024f * 1024f * 1024f
                     }
+                    message.addAttachment(attachmentId, attachmentName, size.toLong())
                 }
             }
 

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebHomework.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/mobidziennik/data/web/MobidziennikWebHomework.kt
@@ -33,14 +33,14 @@ class MobidziennikWebHomework(override val data: DataMobidziennik,
         webGet(TAG, "/mobile/$endpoint") { text ->
             MobidziennikLuckyNumberExtractor(data, text)
 
-            Regexes.MOBIDZIENNIK_HOMEWORK_ROW.findAll(text).forEach { homeworkMatch ->
+            Regexes.MOBIDZIENNIK_MOBILE_HOMEWORK_ROW.findAll(text).forEach { homeworkMatch ->
                 val tableRow = homeworkMatch[1].ifBlank { return@forEach }
 
                 /*val items = Regexes.MOBIDZIENNIK_HOMEWORK_ITEM.findAll(tableRow).map { match ->
                     match[1] to match[2].fixWhiteSpaces()
                 }.toList()*/
 
-                val id = Regexes.MOBIDZIENNIK_HOMEWORK_ID.find(tableRow)?.get(1)?.toLongOrNull() ?: return@forEach
+                val id = Regexes.MOBIDZIENNIK_MOBILE_HOMEWORK_ID.find(tableRow)?.get(1)?.toLongOrNull() ?: return@forEach
                 if (event.id != id)
                     return@forEach
 
@@ -48,12 +48,13 @@ class MobidziennikWebHomework(override val data: DataMobidziennik,
 
                 event.attachmentIds = mutableListOf()
                 event.attachmentNames = mutableListOf()
-                Regexes.MOBIDZIENNIK_HOMEWORK_ATTACHMENT.findAll(tableRow).forEach {
+                Regexes.MOBIDZIENNIK_MOBILE_HOMEWORK_ATTACHMENT.findAll(tableRow).forEach {
                     event.attachmentIds?.add(it[1].toLongOrNull() ?: return@forEach)
                     event.attachmentNames?.add(it[2])
                 }
 
                 event.homeworkBody = ""
+                event.isDownloaded = true
             }
 
             //data.eventList.add(eventObject)

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/podlasie/data/api/PodlasieApiEvents.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/podlasie/data/api/PodlasieApiEvents.kt
@@ -57,6 +57,7 @@ class PodlasieApiEvents(val data: DataPodlasie, val rows: List<JsonObject>) {
                     addedDate = addedDate
             ).apply {
                 homeworkBody = description
+                isDownloaded = true
             }
 
             data.eventList.add(eventObject)

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/podlasie/data/api/PodlasieApiHomework.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/podlasie/data/api/PodlasieApiHomework.kt
@@ -37,6 +37,7 @@ class PodlasieApiHomework(val data: DataPodlasie, val rows: List<JsonObject>) {
                     addedDate = addedDate
             ).apply {
                 homeworkBody = description
+                isDownloaded = true
             }
 
             eventObject.attachmentIds = mutableListOf()

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/vulcan/Vulcan.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/edziennik/vulcan/Vulcan.kt
@@ -164,6 +164,7 @@ class Vulcan(val app: App, val profile: Profile?, val loginStore: LoginStore, va
 
     override fun getEvent(eventFull: EventFull) {
         eventFull.homeworkBody = ""
+        eventFull.isDownloaded = true
 
         EventBus.getDefault().postSticky(EventGetEvent(eventFull))
         completed()

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/messages/MessageFragment.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/modules/messages/MessageFragment.kt
@@ -301,8 +301,8 @@ class MessageFragment : Fragment(), CoroutineScope {
                 it.putInt("profileId", message.profileId)
                 it.putLongArray("attachmentIds", message.attachmentIds!!.toLongArray())
                 it.putStringArray("attachmentNames", message.attachmentNames!!.toTypedArray())
-                //if (message.attachmentSizes.isNotNullNorEmpty())
-                //    it.putLongArray("attachmentSizes", message.attachmentSizes!!.toLongArray())
+                if (message.attachmentSizes.isNotNullNorEmpty())
+                    it.putLongArray("attachmentSizes", message.attachmentSizes!!.toLongArray())
             }, owner = message)
         }
     }


### PR DESCRIPTION
This PR changes the method of scrapping Mobidziennik homework attachments. This fixes displaying the attachment list and saves the correct added date of the homework.

This also restores showing attachment sizes in Message fragment, because for some unknown reason this has been disabled in the past.

Closes #84.