### PR TITLE
[API/Szkolny] Fix user/device registration after API errors.

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/ext/ArrayExtensions.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ext/ArrayExtensions.kt
@@ -59,20 +59,8 @@ fun SparseIntArray.values(): List<Int> {
     return result
 }
 
-fun <K, V> List<Pair<K, V>>.keys(): List<K> {
-    val result = mutableListOf<K>()
-    forEach { pair ->
-        result += pair.first
-    }
-    return result
-}
-fun <K, V> List<Pair<K, V>>.values(): List<V> {
-    val result = mutableListOf<V>()
-    forEach { pair ->
-        result += pair.second
-    }
-    return result
-}
+fun <K, V> List<Pair<K, V>>.keys() = map { it.first }
+fun <K, V> List<Pair<K, V>>.values() = map { it.second }
 
 fun <T> List<T>.toSparseArray(destination: SparseArray<T>, key: (T) -> Int) {
     forEach {


### PR DESCRIPTION
This PR enables saving the updated user/device hash only after a successful API request is performed.
This fixes an issue where the user/device structures were not registered on the API server after an error was encountered in the previous requests.