### PR TITLE
[UI] Fix touch events on swipe refresh pages (API 32+).

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/utils/SwipeRefreshLayoutNoIndicator.java
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/utils/SwipeRefreshLayoutNoIndicator.java
@@ -83,7 +83,6 @@ public class SwipeRefreshLayoutNoIndicator extends SwipeRefreshLayout {
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
-        ev.setSource(0x10000000);
         boolean parentConsumed = parent.onInterceptTouchEvent(ev);
         boolean superConsumed = super.onInterceptTouchEvent(ev);
         return parentConsumed && superConsumed;

--- a/app/src/main/java/pl/szczodrzynski/edziennik/utils/SwipeRefreshLayoutNoIndicator.java
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/utils/SwipeRefreshLayoutNoIndicator.java
@@ -17,6 +17,7 @@
 package pl.szczodrzynski.edziennik.utils;
 
 import android.content.Context;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -83,6 +84,9 @@ public class SwipeRefreshLayoutNoIndicator extends SwipeRefreshLayout {
 
     @Override
     public boolean onInterceptTouchEvent(MotionEvent ev) {
+        if (Build.VERSION.SDK_INT < 32) {
+            ev.setSource(0x10000000);
+        }
         boolean parentConsumed = parent.onInterceptTouchEvent(ev);
         boolean superConsumed = super.onInterceptTouchEvent(ev);
         return parentConsumed && superConsumed;


### PR DESCRIPTION
Fixed issues related to incorrect touch events on messages/grades pages for latest API 32 (Android 12L)