### PR TITLE
Dodaj opcję wyłączenia powiadomień o nie swoim szczęśliwym numerku

### DIFF
--- a/app/src/main/java/pl/szczodrzynski/edziennik/config/ConfigSync.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/config/ConfigSync.kt
@@ -27,6 +27,8 @@ class ConfigSync(base: Config) {
     var quietHoursEnd by base.config<Time?>(null)
     var quietDuringLessons by base.config<Boolean>(false)
 
+    var luckyNumberOnlyMe by base.config<Boolean>(false)
+
     // FCM Tokens
     var tokenApp by base.config<String?>(null)
     var tokenMobidziennik by base.config<String?>(null)

--- a/app/src/main/java/pl/szczodrzynski/edziennik/data/api/task/Notifications.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/data/api/task/Notifications.kt
@@ -321,6 +321,7 @@ class Notifications(val app: App, val notifications: MutableList<Notification>, 
         luckyNumbers.removeAll { it.date < today }
         luckyNumbers.forEach { luckyNumber ->
             val profile = profiles.singleOrNull { it.id == luckyNumber.profileId } ?: return@forEach
+            if(app.config.sync.luckyNumberOnlyMe && profile.studentNumber != luckyNumber.number) return@forEach
             val text = when (profile.studentNumber != -1 && profile.studentNumber == luckyNumber.number) {
                 true -> when (luckyNumber.date.value) {
                     todayValue -> R.string.notification_lucky_number_yours_format

--- a/app/src/main/java/pl/szczodrzynski/edziennik/ui/settings/cards/SettingsSyncCard.kt
+++ b/app/src/main/java/pl/szczodrzynski/edziennik/ui/settings/cards/SettingsSyncCard.kt
@@ -12,7 +12,6 @@ import android.os.Build.VERSION_CODES
 import android.provider.Settings
 import com.danielstone.materialaboutlibrary.model.MaterialAboutCard
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
-import pl.szczodrzynski.edziennik.MainActivity
 import pl.szczodrzynski.edziennik.R
 import pl.szczodrzynski.edziennik.ext.after
 import pl.szczodrzynski.edziennik.ext.getSyncInterval
@@ -128,7 +127,15 @@ class SettingsSyncCard(util: SettingsUtil) : SettingsCard(util) {
         ) {
             NotificationFilterDialog(activity).show()
         },
-
+        util.createPropertyItem(
+            text = R.string.settings_lucky_number_only_me_text,
+            subText = R.string.settings_lucky_number_only_me_descryption,
+            icon = CommunityMaterial.Icon.cmd_bell_cancel,
+            value = configGlobal.sync.luckyNumberOnlyMe
+        ) { _, it ->
+            configGlobal.sync.luckyNumberOnlyMe = it
+            UpdateWorker.rescheduleNext(app)
+        },
         util.createPropertyActionItem(
             text = R.string.settings_sync_quiet_hours_text,
             subText = R.string.settings_sync_quiet_hours_subtext_disabled,
@@ -166,7 +173,6 @@ class SettingsSyncCard(util: SettingsUtil) : SettingsCard(util) {
             configGlobal.sync.notifyAboutUpdates = it
             UpdateWorker.rescheduleNext(app)
         },
-
         if (SDK_INT >= VERSION_CODES.KITKAT)
             util.createActionItem(
                 text = R.string.settings_sync_notifications_settings_text,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1553,4 +1553,7 @@
     <string name="home_timetable_all_lessons">Wszystkie lekcje:</string>
     <string name="agenda_config_subject_important">Wyświetl nazwę przedmiotu zamiast rodzaju</string>
     <string name="menu_timetable_sync">Odśwież wybrany tydzień</string>
+    <string name="settings_lucky_number_only_me_text">Szczęśliwy Numerek tylko dla Ciebie</string>
+    <string name="settings_lucky_number_only_me_descryption">Wysyła powiadomienia o Szczęśliwym Numerku jedynie gdy Ty zostaniesz wybrany</string>
+
 </resources>


### PR DESCRIPTION
Dodaje opcję w ustawieniach która powoduje że gdy szczęśliwy numerek wypadnie na kogoś innego to nie jest wysyłane powiadomienie.
Codzienny spam że numer `X` ma dziś szczęśliwy numer może być irytujący więc wiele osób może uznać to za użyteczne

